### PR TITLE
Update CodingTrain Patreon page link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This course focuses on programming strategies and techniques behind procedural a
 - Daniel Shiffman, Tuesdays, 9:00am-11:30am
 - [All class dates](http://help.itp.nyu.edu/curriculum/fall-class-dates)
 - [Office Hours](https://itp.nyu.edu/inwiki/Signup/Shiffman)
-- In addition to the ITP physical class, I am running an online version of the class for [Patreon](https://www.patreon.com/codingrainbow) subscribers.  ITP students will receive a slack invite should they want to participate.  YouTube live stream sessions TBA.
+- In addition to the ITP physical class, I am running an online version of the class for [Patreon](https://www.patreon.com/codingtrain) subscribers.  ITP students will receive a slack invite should they want to participate.  YouTube live stream sessions TBA.
 
 ## Mailing List
 * [Join ITP A2Z Google Group](https://groups.google.com/a/nyu.edu/forum/#!forum/a2z-group/).  This is for the ITP physical class only.


### PR DESCRIPTION
Hey Dan! I'm not sure if I'm right to think that the patreon link is not updated with your own patreon profile. The current link takes me to another profile where I found no sign of you or CodingTrain except the old name `CodingRainbow`. So, I thought that, this might be a mistake because of the migration from `CodingRainbow` to `CodingTrain` OR it's just my mistake thinking like this way.

P.S. Thank you for making me the actual me! Apart from this link fixing, there are a lot more things to talk about how you changed my surrounding and guiding me towards the path I always wanted to walk over and discover. Maybe that's the story for another day :)